### PR TITLE
Small fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.10
 
 RUN apt-get update
 RUN apt-get install -y bash
@@ -10,5 +10,5 @@ RUN apt-get install -y meson
 RUN apt-get install -y clang
 RUN apt-get install -y git
 
-RUN git clone https://github.com/ocornut/imgui.git imgui
-RUN git clone https://github.com/epezent/implot implot
+RUN git clone --depth 1 --branch v1.88 https://github.com/ocornut/imgui.git imgui
+RUN git clone --depth 1 --branch v0.14 https://github.com/epezent/implot.git implot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - .:/code
     working_dir: /code
-    #entrypoint: meson setup builddir /code --native-file=native.build
+    # entrypoint: meson setup builddir /code --native-file=native.build
   gui:
     image: my-app:latest
     build: .
@@ -16,6 +16,7 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - .:/code
+      - $HOME/.Xauthority:/root/.Xauthority:rw
     working_dir: /code
     network_mode: host
     entrypoint: ./builddir/app


### PR DESCRIPTION
### Changed
- Fixed the used Ubuntu version in the latest available version (22.10) in the `Dockerfile`
- Fixed the versions of the cloned repos in the `Dockerfile` to their latest released versions

There was one additional change required in the `docker-compose.yml` file to get the GUI working on my setup. I had the following error
`Glfw Error 65544: X11: Failed to open display :1`

I'm running Ubuntu 18.04. 

Btw I'm missing some changelog here :)