### PR TITLE
Adds missing std::bind() in thread_pool.hpp and unit test

### DIFF
--- a/src/lib/thread_pool/thread_pool_test.cpp
+++ b/src/lib/thread_pool/thread_pool_test.cpp
@@ -10,6 +10,11 @@ void EmptyTask()
 {
 }
 
+void Checksum(const std::uint32_t num, std::atomic_uint64_t* checksum)
+{
+    *checksum += num;
+}
+
 TEST_CASE("Construction and deconstruction", "[thread_pool]")
 {
     BENCHMARK("Construction and destruction")
@@ -35,4 +40,25 @@ TEST_CASE("N tasks", "[thread_pool]")
             results.pop();
         }
     };
+}
+
+TEST_CASE("N tasks checksum", "[thread_pool]")
+{
+    ThreadPool thread_pool{4};
+    std::queue<std::future<void>> results;
+    std::atomic_uint64_t checksum{0};
+    std::uint64_t localChecksum{0};
+
+    for (std::uint32_t n = 0; n < 1000; ++n)
+    {
+        results.emplace(thread_pool.AddTask(Checksum, n, &checksum));
+        localChecksum += n;
+    }
+    while (results.size())
+    {
+        results.front().get();
+        results.pop();
+    }
+
+    CHECK(checksum == localChecksum);
 }


### PR DESCRIPTION
Fixed missing std::bind(), and added a unit test that covers function arguments and sanity checks the execution of tasks.
Closes #6.